### PR TITLE
Add direct scene parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ The `rt` crate provides a CLI to render a scene file. A sample scene is included
 cargo run --package rt -- input.scene.rt
 ```
 
+Scenes can also be loaded programmatically with `scene::Scene::from_json_value`:
+
+```rust
+let json = std::fs::read_to_string("input.scene.rt").unwrap();
+let value = jsonc::parse(&json).unwrap();
+let dummy_loader = MyLoader; // implements `scene::ImageLoader`
+let scene = scene::Scene::from_json_value(value, 1.0, &dummy_loader).unwrap();
+```
+
 Use `--help` to see additional command line options such as output image dimensions and camera parameters.
 
 ## Formatting and tests

--- a/scene/src/camera/mod.rs
+++ b/scene/src/camera/mod.rs
@@ -1,24 +1,13 @@
 use core::types::rt::Camera;
 use jsonc::Value;
-use perspective::DeserializablePerspectiveCamera;
+use perspective as persp;
 
 pub mod perspective;
 
-#[derive(Debug)]
-pub enum DeserializableCamera {
-    Perspective(DeserializablePerspectiveCamera),
-}
-
-impl DeserializableCamera {
-    pub fn into_camera(self, screen_aspect_ratio: f64) -> Box<dyn Camera + Send + Sync> {
-        match self {
-            DeserializableCamera::Perspective(c) => c.into_camera(screen_aspect_ratio),
-        }
-    }
-
-    pub fn from_json(json: &Value) -> Result<DeserializableCamera, String> {
-        return Ok(DeserializableCamera::Perspective(
-            DeserializablePerspectiveCamera::from_json(json)?,
-        ));
-    }
+/// Parse a camera directly from a JSON value.
+pub fn from_json_value(
+    json: &Value,
+    screen_aspect_ratio: f64,
+) -> Result<Box<dyn Camera + Send + Sync>, String> {
+    persp::from_json_value(json, screen_aspect_ratio)
 }

--- a/scene/src/camera/perspective.rs
+++ b/scene/src/camera/perspective.rs
@@ -5,179 +5,6 @@ use core::types::{
 use jsonc::Value;
 
 #[derive(Clone, Debug)]
-pub struct AspectRatio {
-    aspect_ratio: f64,
-}
-
-#[derive(Clone, Debug)]
-pub enum FovMode {
-    X,
-    Y,
-    Cover(AspectRatio),
-    Contain(AspectRatio),
-}
-
-#[derive(Clone, Debug)]
-pub struct DeserializablePerspectiveCamera {
-    fov: f64,
-    fov_mode: FovMode,
-    position: Position,
-    direction: Direction,
-}
-
-impl DeserializablePerspectiveCamera {
-    pub fn from_json(json: &Value) -> Result<DeserializablePerspectiveCamera, String> {
-        let dict = match json {
-            Value::Object(dict) => dict,
-            _ => return Err("Camera must be a JSON object".to_string()),
-        };
-
-        let fov_json = dict.get("fov").ok_or("Missing required field: fov")?;
-        let (fov, fov_mode) = Self::parse_fov(fov_json)?;
-
-        let position_json = dict
-            .get("position")
-            .ok_or("Missing required field: position")?;
-        let position = Self::parse_position(position_json)?;
-
-        let direction = if let Some(direction_json) = dict.get("direction") {
-            Self::parse_direction(direction_json)?
-        } else if let Some(look_at_json) = dict.get("lookAt") {
-            let look_at = Self::parse_position(look_at_json)?;
-            Direction::new(*(look_at - position))
-        } else {
-            return Err("Camera must have either 'direction' or 'lookAt' field".to_string());
-        };
-
-        Ok(DeserializablePerspectiveCamera {
-            fov,
-            fov_mode,
-            position,
-            direction,
-        })
-    }
-
-    fn parse_fov(json: &Value) -> Result<(f64, FovMode), String> {
-        let dict = match json {
-            Value::Object(dict) => dict,
-            _ => return Err("fov must be a JSON object".to_string()),
-        };
-
-        if let Some(x_json) = dict.get("x") {
-            let angle = Self::parse_angle(x_json)?;
-            Ok((angle, FovMode::X))
-        } else if let Some(y_json) = dict.get("y") {
-            let angle = Self::parse_angle(y_json)?;
-            Ok((angle, FovMode::Y))
-        } else if let Some(min_json) = dict.get("min") {
-            let angle = Self::parse_angle(min_json)?;
-            Ok((angle, FovMode::Contain(AspectRatio { aspect_ratio: 1.0 })))
-        } else if let Some(max_json) = dict.get("max") {
-            let angle = Self::parse_angle(max_json)?;
-            Ok((angle, FovMode::Cover(AspectRatio { aspect_ratio: 1.0 })))
-        } else {
-            Err("fov must have one of: 'x', 'y', 'min', or 'max' field".to_string())
-        }
-    }
-
-    fn parse_angle(json: &Value) -> Result<f64, String> {
-        let dict = match json {
-            Value::Object(dict) => dict,
-            _ => return Err("angle must be a JSON object".to_string()),
-        };
-
-        if let Some(Value::Number(degree)) = dict.get("degree") {
-            Ok(*degree)
-        } else if let Some(Value::Number(radian)) = dict.get("radian") {
-            Ok(radian.to_degrees())
-        } else {
-            Err("angle must have either 'degree' or 'radian' field".to_string())
-        }
-    }
-
-    fn parse_position(json: &Value) -> Result<Position, String> {
-        let array = match json {
-            Value::Array(array) if array.len() == 3 => array,
-            _ => return Err("position must be an array of 3 numbers".to_string()),
-        };
-
-        let x = match &array[0] {
-            Value::Number(n) => *n,
-            _ => return Err("position[0] must be a number".to_string()),
-        };
-        let y = match &array[1] {
-            Value::Number(n) => *n,
-            _ => return Err("position[1] must be a number".to_string()),
-        };
-        let z = match &array[2] {
-            Value::Number(n) => *n,
-            _ => return Err("position[2] must be a number".to_string()),
-        };
-
-        Ok(Position::new(Vec3::new(x, y, z)))
-    }
-
-    fn parse_direction(json: &Value) -> Result<Direction, String> {
-        let array = match json {
-            Value::Array(array) if array.len() == 3 => array,
-            _ => return Err("direction must be an array of 3 numbers".to_string()),
-        };
-
-        let x = match &array[0] {
-            Value::Number(n) => *n,
-            _ => return Err("direction[0] must be a number".to_string()),
-        };
-        let y = match &array[1] {
-            Value::Number(n) => *n,
-            _ => return Err("direction[1] must be a number".to_string()),
-        };
-        let z = match &array[2] {
-            Value::Number(n) => *n,
-            _ => return Err("direction[2] must be a number".to_string()),
-        };
-
-        Ok(Direction::new(Vec3::new(x, y, z)))
-    }
-
-    pub fn into_camera(self, screen_aspect_ratio: f64) -> Box<dyn Camera + Send + Sync> {
-        let (tan_half_fov_x, tan_half_fov_y) = match self.fov_mode {
-            FovMode::X => {
-                let tan_half_fov_x = (self.fov.to_radians() / 2.0).tan();
-                let tan_half_fov_y = tan_half_fov_x / screen_aspect_ratio;
-                (tan_half_fov_x, tan_half_fov_y)
-            }
-            FovMode::Y => {
-                let tan_half_fov_y = (self.fov.to_radians() / 2.0).tan();
-                let tan_half_fov_x = tan_half_fov_y * screen_aspect_ratio;
-                (tan_half_fov_x, tan_half_fov_y)
-            }
-            FovMode::Cover(aspect_ratio) => {
-                let tan_half_fov_x = (self.fov.to_radians() / 2.0).tan();
-                let tan_half_fov_y = tan_half_fov_x / aspect_ratio.aspect_ratio;
-                let scale = (screen_aspect_ratio / aspect_ratio.aspect_ratio).max(1.0);
-                (tan_half_fov_x * scale, tan_half_fov_y * scale)
-            }
-            FovMode::Contain(aspect_ratio) => {
-                let tan_half_fov_x = (self.fov.to_radians() / 2.0).tan();
-                let tan_half_fov_y = tan_half_fov_x / aspect_ratio.aspect_ratio;
-                let scale = (screen_aspect_ratio / aspect_ratio.aspect_ratio).min(1.0);
-                (tan_half_fov_x * scale, tan_half_fov_y * scale)
-            }
-        };
-
-        let right = self.direction.cross(Vec3::Z).normalize();
-        let up = right.cross(*self.direction).normalize();
-        Box::new(PerspectiveCamera {
-            tan_half_fov_x,
-            tan_half_fov_y,
-            position: self.position,
-            direction: self.direction,
-            right,
-            up,
-        })
-    }
-}
-
 struct PerspectiveCamera {
     tan_half_fov_x: f64,
     tan_half_fov_y: f64,
@@ -191,12 +18,169 @@ impl Camera for PerspectiveCamera {
     fn ray(&self, x: f64, y: f64) -> Ray {
         let dir_x = (2.0 * x - 1.0) * self.tan_half_fov_x;
         let dir_z = (1.0 - 2.0 * y) * self.tan_half_fov_y;
-
         let direction = Direction::new(*self.direction + dir_x * self.right + self.up * dir_z);
-
         Ray {
             origin: self.position,
             direction,
         }
     }
+}
+
+#[derive(Clone, Debug)]
+struct AspectRatio {
+    aspect_ratio: f64,
+}
+
+#[derive(Clone, Debug)]
+enum FovMode {
+    X,
+    Y,
+    Cover(AspectRatio),
+    Contain(AspectRatio),
+}
+
+pub fn from_json_value(
+    json: &Value,
+    screen_aspect_ratio: f64,
+) -> Result<Box<dyn Camera + Send + Sync>, String> {
+    let dict = match json {
+        Value::Object(dict) => dict,
+        _ => return Err("Camera must be a JSON object".to_string()),
+    };
+
+    let fov_json = dict.get("fov").ok_or("Missing required field: fov")?;
+    let (fov, fov_mode) = parse_fov(fov_json)?;
+
+    let position_json = dict
+        .get("position")
+        .ok_or("Missing required field: position")?;
+    let position = parse_position(position_json)?;
+
+    let direction = if let Some(direction_json) = dict.get("direction") {
+        parse_direction(direction_json)?
+    } else if let Some(look_at_json) = dict.get("lookAt") {
+        let look_at = parse_position(look_at_json)?;
+        Direction::new(*(look_at - position))
+    } else {
+        return Err("Camera must have either 'direction' or 'lookAt' field".to_string());
+    };
+
+    let (tan_half_fov_x, tan_half_fov_y) = match fov_mode {
+        FovMode::X => {
+            let tan_half_fov_x = (fov.to_radians() / 2.0).tan();
+            let tan_half_fov_y = tan_half_fov_x / screen_aspect_ratio;
+            (tan_half_fov_x, tan_half_fov_y)
+        }
+        FovMode::Y => {
+            let tan_half_fov_y = (fov.to_radians() / 2.0).tan();
+            let tan_half_fov_x = tan_half_fov_y * screen_aspect_ratio;
+            (tan_half_fov_x, tan_half_fov_y)
+        }
+        FovMode::Cover(aspect_ratio) => {
+            let tan_half_fov_x = (fov.to_radians() / 2.0).tan();
+            let tan_half_fov_y = tan_half_fov_x / aspect_ratio.aspect_ratio;
+            let scale = (screen_aspect_ratio / aspect_ratio.aspect_ratio).max(1.0);
+            (tan_half_fov_x * scale, tan_half_fov_y * scale)
+        }
+        FovMode::Contain(aspect_ratio) => {
+            let tan_half_fov_x = (fov.to_radians() / 2.0).tan();
+            let tan_half_fov_y = tan_half_fov_x / aspect_ratio.aspect_ratio;
+            let scale = (screen_aspect_ratio / aspect_ratio.aspect_ratio).min(1.0);
+            (tan_half_fov_x * scale, tan_half_fov_y * scale)
+        }
+    };
+
+    let right = direction.cross(Vec3::Z).normalize();
+    let up = right.cross(*direction).normalize();
+
+    Ok(Box::new(PerspectiveCamera {
+        tan_half_fov_x,
+        tan_half_fov_y,
+        position,
+        direction,
+        right,
+        up,
+    }))
+}
+
+fn parse_fov(json: &Value) -> Result<(f64, FovMode), String> {
+    let dict = match json {
+        Value::Object(dict) => dict,
+        _ => return Err("fov must be a JSON object".to_string()),
+    };
+
+    if let Some(x_json) = dict.get("x") {
+        let angle = parse_angle(x_json)?;
+        Ok((angle, FovMode::X))
+    } else if let Some(y_json) = dict.get("y") {
+        let angle = parse_angle(y_json)?;
+        Ok((angle, FovMode::Y))
+    } else if let Some(min_json) = dict.get("min") {
+        let angle = parse_angle(min_json)?;
+        Ok((angle, FovMode::Contain(AspectRatio { aspect_ratio: 1.0 })))
+    } else if let Some(max_json) = dict.get("max") {
+        let angle = parse_angle(max_json)?;
+        Ok((angle, FovMode::Cover(AspectRatio { aspect_ratio: 1.0 })))
+    } else {
+        Err("fov must have one of: 'x', 'y', 'min', or 'max' field".to_string())
+    }
+}
+
+fn parse_angle(json: &Value) -> Result<f64, String> {
+    let dict = match json {
+        Value::Object(dict) => dict,
+        _ => return Err("angle must be a JSON object".to_string()),
+    };
+
+    if let Some(Value::Number(degree)) = dict.get("degree") {
+        Ok(*degree)
+    } else if let Some(Value::Number(radian)) = dict.get("radian") {
+        Ok(radian.to_degrees())
+    } else {
+        Err("angle must have either 'degree' or 'radian' field".to_string())
+    }
+}
+
+fn parse_position(json: &Value) -> Result<Position, String> {
+    let array = match json {
+        Value::Array(array) if array.len() == 3 => array,
+        _ => return Err("position must be an array of 3 numbers".to_string()),
+    };
+
+    let x = match &array[0] {
+        Value::Number(n) => *n,
+        _ => return Err("position[0] must be a number".to_string()),
+    };
+    let y = match &array[1] {
+        Value::Number(n) => *n,
+        _ => return Err("position[1] must be a number".to_string()),
+    };
+    let z = match &array[2] {
+        Value::Number(n) => *n,
+        _ => return Err("position[2] must be a number".to_string()),
+    };
+
+    Ok(Position::new(Vec3::new(x, y, z)))
+}
+
+fn parse_direction(json: &Value) -> Result<Direction, String> {
+    let array = match json {
+        Value::Array(array) if array.len() == 3 => array,
+        _ => return Err("direction must be an array of 3 numbers".to_string()),
+    };
+
+    let x = match &array[0] {
+        Value::Number(n) => *n,
+        _ => return Err("direction[0] must be a number".to_string()),
+    };
+    let y = match &array[1] {
+        Value::Number(n) => *n,
+        _ => return Err("direction[1] must be a number".to_string()),
+    };
+    let z = match &array[2] {
+        Value::Number(n) => *n,
+        _ => return Err("direction[2] must be a number".to_string()),
+    };
+
+    Ok(Direction::new(Vec3::new(x, y, z)))
 }

--- a/scene/src/light/mod.rs
+++ b/scene/src/light/mod.rs
@@ -9,233 +9,211 @@ pub mod directional;
 pub mod point;
 pub mod spot;
 
-pub enum DeserializableLight {
-    Point(PointLight),
-    Directional(DirectionalLight),
-    Spot(SpotLight),
+/// Parse a light directly from a JSON value.
+pub fn from_json_value(json: &Value) -> Result<Box<dyn Light + Send + Sync>, String> {
+    let dict = match json {
+        Value::Object(dict) => dict,
+        _ => return Err("Light must be a JSON object".to_string()),
+    };
+
+    let type_str = match dict.get("type") {
+        Some(Value::String(s)) => s,
+        _ => return Err("Light must have a 'type' field with string value".to_string()),
+    };
+
+    let light: Box<dyn Light + Send + Sync> = match type_str.as_str() {
+        "point" => {
+            let color_json = dict.get("color").ok_or("Missing required field: color")?;
+            let color = parse_hdr_color(color_json)?;
+
+            let position_json = dict
+                .get("position")
+                .ok_or("Missing required field: position")?;
+            let position = parse_position(position_json)?;
+
+            let range = if let Some(Value::Number(r)) = dict.get("range") {
+                if *r <= 0.0 {
+                    return Err("range must be greater than 0".to_string());
+                }
+                *r
+            } else {
+                f64::INFINITY
+            };
+
+            let attenuation = if let Some(Value::Bool(a)) = dict.get("attenuation") {
+                *a
+            } else {
+                true
+            };
+            Box::new(PointLight::new(color, position, range, attenuation))
+        }
+        "directional" => {
+            let color_json = dict.get("color").ok_or("Missing required field: color")?;
+            let color = parse_hdr_color(color_json)?;
+
+            let direction_json = dict
+                .get("direction")
+                .ok_or("Missing required field: direction")?;
+            let direction = parse_direction(direction_json)?;
+
+            Box::new(DirectionalLight::new(color, direction))
+        }
+        "spot" => {
+            let color_json = dict.get("color").ok_or("Missing required field: color")?;
+            let color = parse_hdr_color(color_json)?;
+
+            let position_json = dict
+                .get("position")
+                .ok_or("Missing required field: position")?;
+            let position = parse_position(position_json)?;
+
+            let angle_json = dict.get("angle").ok_or("Missing required field: angle")?;
+            let angle = parse_angle(angle_json)?;
+
+            let direction_json = dict
+                .get("direction")
+                .ok_or("Missing required field: direction")?;
+            let direction = parse_direction(direction_json)?;
+
+            let range = if let Some(Value::Number(r)) = dict.get("range") {
+                if *r <= 0.0 {
+                    return Err("range must be greater than 0".to_string());
+                }
+                *r
+            } else {
+                f64::INFINITY
+            };
+
+            let attenuation = if let Some(Value::Bool(a)) = dict.get("attenuation") {
+                *a
+            } else {
+                true
+            };
+            Box::new(SpotLight::new(
+                color,
+                position,
+                angle,
+                direction,
+                range,
+                attenuation,
+            ))
+        }
+        _ => return Err(format!("Unknown light type: {}", type_str)),
+    };
+
+    Ok(light)
 }
 
-impl DeserializableLight {
-    pub fn into_light(self) -> Box<dyn Light + Send + Sync> {
-        match self {
-            DeserializableLight::Point(c) => Box::new(c),
-            DeserializableLight::Directional(c) => Box::new(c),
-            DeserializableLight::Spot(c) => Box::new(c),
-        }
-    }
-
-    pub fn from_json(json: &Value) -> Result<DeserializableLight, String> {
-        let dict = match json {
-            Value::Object(dict) => dict,
-            _ => return Err("Light must be a JSON object".to_string()),
-        };
-
-        let type_str = match dict.get("type") {
-            Some(Value::String(s)) => s,
-            _ => return Err("Light must have a 'type' field with string value".to_string()),
-        };
-
-        match type_str.as_str() {
-            "point" => {
-                let color_json = dict.get("color").ok_or("Missing required field: color")?;
-                let color = Self::parse_hdr_color(color_json)?;
-
-                let position_json = dict
-                    .get("position")
-                    .ok_or("Missing required field: position")?;
-                let position = Self::parse_position(position_json)?;
-
-                let range = if let Some(Value::Number(r)) = dict.get("range") {
-                    if *r <= 0.0 {
-                        return Err("range must be greater than 0".to_string());
+fn parse_hdr_color(json: &Value) -> Result<HDRColor, String> {
+    match json {
+        Value::Array(array) if array.len() == 3 => {
+            let r = match &array[0] {
+                Value::Number(n) => {
+                    if *n < 0.0 || !n.is_finite() {
+                        return Err("color[0] must be a non-negative finite number".to_string());
                     }
-                    *r
-                } else {
-                    f64::INFINITY
-                };
-
-                let attenuation = if let Some(Value::Bool(a)) = dict.get("attenuation") {
-                    *a
-                } else {
-                    true
-                };
-
-                Ok(DeserializableLight::Point(PointLight::new(
-                    color,
-                    position,
-                    range,
-                    attenuation,
-                )))
-            }
-            "directional" => {
-                let color_json = dict.get("color").ok_or("Missing required field: color")?;
-                let color = Self::parse_hdr_color(color_json)?;
-
-                let direction_json = dict
-                    .get("direction")
-                    .ok_or("Missing required field: direction")?;
-                let direction = Self::parse_direction(direction_json)?;
-
-                Ok(DeserializableLight::Directional(DirectionalLight::new(
-                    color, direction,
-                )))
-            }
-            "spot" => {
-                let color_json = dict.get("color").ok_or("Missing required field: color")?;
-                let color = Self::parse_hdr_color(color_json)?;
-
-                let position_json = dict
-                    .get("position")
-                    .ok_or("Missing required field: position")?;
-                let position = Self::parse_position(position_json)?;
-
-                let angle_json = dict.get("angle").ok_or("Missing required field: angle")?;
-                let angle = Self::parse_angle(angle_json)?;
-
-                let direction_json = dict
-                    .get("direction")
-                    .ok_or("Missing required field: direction")?;
-                let direction = Self::parse_direction(direction_json)?;
-
-                let range = if let Some(Value::Number(r)) = dict.get("range") {
-                    if *r <= 0.0 {
-                        return Err("range must be greater than 0".to_string());
-                    }
-                    *r
-                } else {
-                    f64::INFINITY
-                };
-
-                let attenuation = if let Some(Value::Bool(a)) = dict.get("attenuation") {
-                    *a
-                } else {
-                    true
-                };
-
-                Ok(DeserializableLight::Spot(SpotLight::new(
-                    color,
-                    position,
-                    angle,
-                    direction,
-                    range,
-                    attenuation,
-                )))
-            }
-            _ => Err(format!("Unknown light type: {}", type_str)),
-        }
-    }
-
-    fn parse_hdr_color(json: &Value) -> Result<HDRColor, String> {
-        match json {
-            Value::Array(array) if array.len() == 3 => {
-                let r = match &array[0] {
-                    Value::Number(n) => {
-                        if *n < 0.0 || !n.is_finite() {
-                            return Err("color[0] must be a non-negative finite number".to_string());
-                        }
-                        *n
-                    }
-                    _ => return Err("color[0] must be a number".to_string()),
-                };
-                let g = match &array[1] {
-                    Value::Number(n) => {
-                        if *n < 0.0 || !n.is_finite() {
-                            return Err("color[1] must be a non-negative finite number".to_string());
-                        }
-                        *n
-                    }
-                    _ => return Err("color[1] must be a number".to_string()),
-                };
-                let b = match &array[2] {
-                    Value::Number(n) => {
-                        if *n < 0.0 || !n.is_finite() {
-                            return Err("color[2] must be a non-negative finite number".to_string());
-                        }
-                        *n
-                    }
-                    _ => return Err("color[2] must be a number".to_string()),
-                };
-                Ok(HDRColor { r, g, b })
-            }
-            _ => Err("color must be an array of 3 numbers".to_string()),
-        }
-    }
-
-    fn parse_position(json: &Value) -> Result<Position, String> {
-        match json {
-            Value::Array(array) if array.len() == 3 => {
-                let x = match &array[0] {
-                    Value::Number(n) => *n,
-                    _ => return Err("position[0] must be a number".to_string()),
-                };
-                let y = match &array[1] {
-                    Value::Number(n) => *n,
-                    _ => return Err("position[1] must be a number".to_string()),
-                };
-                let z = match &array[2] {
-                    Value::Number(n) => *n,
-                    _ => return Err("position[2] must be a number".to_string()),
-                };
-                Ok(Position::new(Vec3::new(x, y, z)))
-            }
-            _ => Err("position must be an array of 3 numbers".to_string()),
-        }
-    }
-
-    fn parse_direction(json: &Value) -> Result<Direction, String> {
-        match json {
-            Value::Array(array) if array.len() == 3 => {
-                let x = match &array[0] {
-                    Value::Number(n) => {
-                        if !n.is_finite() {
-                            return Err("direction[0] must be a finite number".to_string());
-                        }
-                        *n
-                    }
-                    _ => return Err("direction[0] must be a number".to_string()),
-                };
-                let y = match &array[1] {
-                    Value::Number(n) => {
-                        if !n.is_finite() {
-                            return Err("direction[1] must be a finite number".to_string());
-                        }
-                        *n
-                    }
-                    _ => return Err("direction[1] must be a number".to_string()),
-                };
-                let z = match &array[2] {
-                    Value::Number(n) => {
-                        if !n.is_finite() {
-                            return Err("direction[2] must be a finite number".to_string());
-                        }
-                        *n
-                    }
-                    _ => return Err("direction[2] must be a number".to_string()),
-                };
-
-                let vec = Vec3::new(x, y, z);
-                if vec.length() < 1e-10 {
-                    return Err("direction vector cannot be zero or near-zero".to_string());
+                    *n
                 }
-
-                Ok(Direction::new(vec))
-            }
-            _ => Err("direction must be an array of 3 numbers".to_string()),
+                _ => return Err("color[0] must be a number".to_string()),
+            };
+            let g = match &array[1] {
+                Value::Number(n) => {
+                    if *n < 0.0 || !n.is_finite() {
+                        return Err("color[1] must be a non-negative finite number".to_string());
+                    }
+                    *n
+                }
+                _ => return Err("color[1] must be a number".to_string()),
+            };
+            let b = match &array[2] {
+                Value::Number(n) => {
+                    if *n < 0.0 || !n.is_finite() {
+                        return Err("color[2] must be a non-negative finite number".to_string());
+                    }
+                    *n
+                }
+                _ => return Err("color[2] must be a number".to_string()),
+            };
+            Ok(HDRColor { r, g, b })
         }
+        _ => Err("color must be an array of 3 numbers".to_string()),
     }
+}
 
-    fn parse_angle(json: &Value) -> Result<f64, String> {
-        let dict = match json {
-            Value::Object(dict) => dict,
-            _ => return Err("angle must be a JSON object".to_string()),
-        };
-
-        if let Some(Value::Number(degree)) = dict.get("degree") {
-            Ok(*degree)
-        } else if let Some(Value::Number(radian)) = dict.get("radian") {
-            Ok(radian.to_degrees())
-        } else {
-            Err("angle must have either 'degree' or 'radian' field".to_string())
+fn parse_position(json: &Value) -> Result<Position, String> {
+    match json {
+        Value::Array(array) if array.len() == 3 => {
+            let x = match &array[0] {
+                Value::Number(n) => *n,
+                _ => return Err("position[0] must be a number".to_string()),
+            };
+            let y = match &array[1] {
+                Value::Number(n) => *n,
+                _ => return Err("position[1] must be a number".to_string()),
+            };
+            let z = match &array[2] {
+                Value::Number(n) => *n,
+                _ => return Err("position[2] must be a number".to_string()),
+            };
+            Ok(Position::new(Vec3::new(x, y, z)))
         }
+        _ => Err("position must be an array of 3 numbers".to_string()),
+    }
+}
+
+fn parse_direction(json: &Value) -> Result<Direction, String> {
+    match json {
+        Value::Array(array) if array.len() == 3 => {
+            let x = match &array[0] {
+                Value::Number(n) => {
+                    if !n.is_finite() {
+                        return Err("direction[0] must be a finite number".to_string());
+                    }
+                    *n
+                }
+                _ => return Err("direction[0] must be a number".to_string()),
+            };
+            let y = match &array[1] {
+                Value::Number(n) => {
+                    if !n.is_finite() {
+                        return Err("direction[1] must be a finite number".to_string());
+                    }
+                    *n
+                }
+                _ => return Err("direction[1] must be a number".to_string()),
+            };
+            let z = match &array[2] {
+                Value::Number(n) => {
+                    if !n.is_finite() {
+                        return Err("direction[2] must be a finite number".to_string());
+                    }
+                    *n
+                }
+                _ => return Err("direction[2] must be a number".to_string()),
+            };
+
+            let vec = Vec3::new(x, y, z);
+            if vec.length() < 1e-10 {
+                return Err("direction vector cannot be zero or near-zero".to_string());
+            }
+
+            Ok(Direction::new(vec))
+        }
+        _ => Err("direction must be an array of 3 numbers".to_string()),
+    }
+}
+
+fn parse_angle(json: &Value) -> Result<f64, String> {
+    let dict = match json {
+        Value::Object(dict) => dict,
+        _ => return Err("angle must be a JSON object".to_string()),
+    };
+
+    if let Some(Value::Number(degree)) = dict.get("degree") {
+        Ok(*degree)
+    } else if let Some(Value::Number(radian)) = dict.get("radian") {
+        Ok(radian.to_degrees())
+    } else {
+        Err("angle must have either 'degree' or 'radian' field".to_string())
     }
 }


### PR DESCRIPTION
## Summary
- remove `Deserializable*` camera, light and scene types
- parse JSON directly into runtime types
- expose `Scene::from_json_value` without intermediate builders

## Testing
- `cargo build`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6852fe2cf0088328afbb1a90f4be5b22