### PR TITLE
Fix long-flag formatting error

### DIFF
--- a/rt/src/main.rs
+++ b/rt/src/main.rs
@@ -94,7 +94,7 @@ fn args() -> Result<ArgsResult, Box<dyn Error>> {
                 .iter()
                 .flat_map(|x| vec![x.0, x.1])
                 .collect();
-            let flag = parts[0];
+            let flag = if parts.len() == 2 { parts[0] } else { arg };
             let value = if parts.len() == 2 {
                 Some(parts[1].to_string())
             } else {


### PR DESCRIPTION
# Fix long-flag formatting error \#6 
## Overview
value 없이 long flag를 인자로 전달할 때 프로세스가 panic하는 현상을 수정

Resolves: #6
## PR Type

- [x] fix

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
