### PR TITLE
feat: 렌더러 구조체, 기타 버그 수정

### DIFF
--- a/bmp/src/lib.rs
+++ b/bmp/src/lib.rs
@@ -16,7 +16,10 @@ pub struct MinirtBmp {
 }
 
 impl MinirtBmp {
-    pub fn new(width: usize, height: usize, fill: fn(usize, usize) -> MinirtBmpPixel) -> MinirtBmp {
+    pub fn new<T>(width: usize, height: usize, mut fill: T) -> MinirtBmp
+    where
+        T: FnMut(usize, usize) -> MinirtBmpPixel,
+    {
         let mut extra = Vec::with_capacity(width * height);
         for y in 0..height {
             for x in 0..width {

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -9,3 +9,5 @@ edition = "2021"
 core = { path = "../core" }
 jsonc = { path = "../jsonc" }
 scene = { path = "../scene" }
+bmp = { path = "../bmp" }
+types = { path = "../types" }


### PR DESCRIPTION


# 렌더러 구조체, 기타 버그 수정 \#7
## Overview
- MinirtBmp 구조체의 new 메서드를 제네릭으로 변경(다양한 fill 함수를 지원)

- BRDF 함수 버그 수정

Resolves: #7 
## PR Type
어떤 변경 사항이 있나요?

- [x] feat
- [x] fix


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
