### PR TITLE
fix: 카메라 횡종비, 업벡터, 큐브 크기 버그

### DIFF
--- a/input.scene.rt
+++ b/input.scene.rt
@@ -9,11 +9,11 @@
         "degree": 60
       }
     }, // FOV 가로 세로 중 긴 축으로 60도
-    "position": [0, -10, 0],
+    "position": [-3, 0, -10],
     "lookAt": [0, 0, 0]
   },
   "voidColor": [0.1, 0.2, 0.3],
-  "ambientLight": [0.3, 0.3, 0.3],
+  "ambientLight": [0.01, 0.01, 0.01],
   "hdr": {
     // 기본값
     "gamma": 2.2,
@@ -22,45 +22,37 @@
   "objects": [
     {
       "type": "point",
-      "color": [10.0, 10.0, 10.0],
-      "position": [5, 5, 5],
+      "color": [500.0, 500.0, 500.0],
+      "position": [5, 0, -10],
       "attenuation": true
     },
-    {
-      "type": "directional",
-      "color": [0.6, 0.8, 1.0],
-      "direction": [-0.5, -1, -0.5]
-    },
-    // {
-    //   "type": "spot",
-    //   "color": [1.0, 0.8, 0.6],
-    //   "position": [-3, 4, 2],
-    //   "angle": {
-    //     "radian": 0.785398
-    //   },
-    //   "direction": [0.3, -0.8, 0.2],
-    //   "range": 15,
-    //   "attenuation": false
-    // },
+
     {
       "type": "csg",
       "model": {
         "type": "cube",
         "size": [1, 1, 1],
+        "position": [0, 0, 0],
         "material": {
-          "albedo": [0.6, 0.5, 0.4]
+          "albedo": [0.8, 0.1, 0.1],
+          "metallic": 0.7,
+          "roughness": 0.1
         }
       }
     },
-    // {
-    //   "type": "csg",
-    //   "model": {
-    //     "type": "plane",
-    //     "position": [0, 0, -5],
-    //     "coefficients": { "z": 1 }, // z = 0
-    //     "point": [0, 0, 1], // (0, 0, 1) is not inside of the plane
-    //     "isPointInside": false
-    //   }
-    // }
+
+    {
+      "type": "csg",
+      "model": {
+        "type": "sphere",
+        "radius": 0.5,
+        "position": [2, 0, 0],
+        "material": {
+          "albedo": [0.1, 0.1, 0.1],
+          "metallic": 0.7,
+          "roughness": 0.1
+        }
+      }
+    },
   ]
 }

--- a/rt/src/main.rs
+++ b/rt/src/main.rs
@@ -306,12 +306,11 @@ struct Renderer<'a>(&'a Scene);
 impl<'a> Renderer<'a> {
     fn render(&self, x: usize, y: usize) -> MinirtBmpPixel {
         let scene = &self.0 .0;
-        let width = scene.image_width;
-        let height = scene.image_height;
-        let aspect_ratio = (height as f64) / (width as f64);
+        let width = scene.image_width as f64;
+        let height = scene.image_height as f64;
 
-        let u = (x as f64 + 0.5) / width as f64;
-        let v = (y as f64 + 0.5) / height as f64 * aspect_ratio;
+        let u = (x as f64 + 0.5) / width;
+        let v = (y as f64 + 0.5) / height;
 
         let hdr_color = core::sample(scene, u, v);
         let color = tmp_hdr_to_ldr(hdr_color);

--- a/scene/src/object/cube.rs
+++ b/scene/src/object/cube.rs
@@ -27,14 +27,14 @@ impl RTObject for Cube {
         let mut result = Vec::new();
 
         let min = Position::new(Vec3::new(
-            self.position.x - self.scale.x,
-            self.position.y - self.scale.y,
-            self.position.z - self.scale.z,
+            self.position.x - self.scale.x / 2.0,
+            self.position.y - self.scale.y / 2.0,
+            self.position.z - self.scale.z / 2.0,
         ));
         let max = Position::new(Vec3::new(
-            self.position.x + self.scale.x,
-            self.position.y + self.scale.y,
-            self.position.z + self.scale.z,
+            self.position.x + self.scale.x / 2.0,
+            self.position.y + self.scale.y / 2.0,
+            self.position.z + self.scale.z / 2.0,
         ));
 
         let mut t_min = f64::NEG_INFINITY;


### PR DESCRIPTION
# 카메라 횡종비, 업벡터, 큐브 크기 버그
## Overview
- 카메라 업벡터 수정 월드의  Y에 고정
- 횡종비 버그 수정(화면 짤림, FOV 미적용 이슈)
- 큐브의 크기가 적절하게 수정됨
## PR Type

- [X] fix


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
